### PR TITLE
Use Pool for frames + fix Isort in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,7 +33,7 @@ jobs:
       run: poetry install --no-interaction --no-root && sudo apt update && sudo apt install ffmpeg
 
     - name: Sort imports (isort)
-      run: poetry run isort src
+      run: poetry run isort src test --check-only
 
     - name: Check style (black)
       run: poetry run black src test --check

--- a/src/file/video_file.py
+++ b/src/file/video_file.py
@@ -2,12 +2,12 @@ import os
 import subprocess
 import tempfile
 from glob import glob
+from itertools import repeat
 from multiprocessing import Pool
 
 from .file import File
 from .image_file import ImageFile
 
-from itertools import repeat
 
 def _transform_frame(frame: str, options) -> None:
     frame_file = ImageFile(frame)

--- a/src/file/video_file.py
+++ b/src/file/video_file.py
@@ -2,10 +2,12 @@ import os
 import subprocess
 import tempfile
 from glob import glob
+from multiprocessing import Pool
 
 from .file import File
 from .image_file import ImageFile
 
+from itertools import repeat
 
 def _transform_frame(frame: str, options) -> None:
     frame_file = ImageFile(frame)
@@ -54,8 +56,8 @@ class VideoFile(File):
             # Transform frames
             frame_list = glob(os.path.join(temp_dir, "*.jpg"))
 
-            for frame in frame_list:
-                _transform_frame(frame, options)
+            with Pool() as pool:
+                pool.starmap(_transform_frame, zip(frame_list, repeat(options)))
 
             # Combine frames back into video
             subprocess.run(

--- a/test/file/test_file.py
+++ b/test/file/test_file.py
@@ -1,7 +1,7 @@
 import os
+from os import path
 
 from src.file.file import File, FileType
-from os import path
 
 
 class TestIsInputFile:

--- a/test/file/test_image_file.py
+++ b/test/file/test_image_file.py
@@ -1,12 +1,12 @@
 import os
+from os import path
 
 import pytest
 
 from src.file.file import FileType
 from src.file.image_file import ImageFile
-from os import path
-
 from src.options import Options
+
 from ..helpers import clean_up_sys_argv, handle_sys_args
 
 clean_up_sys_argv()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -6,6 +6,7 @@ import pytest
 from src.file.image_file import ImageFile
 from src.file.video_file import VideoFile
 from src.main import main
+
 from .helpers import clean_up_sys_argv, handle_sys_args
 
 clean_up_sys_argv()

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -2,6 +2,7 @@ import pytest
 
 from src.file.file import FileType
 from src.options import Options
+
 from .helpers import clean_up_sys_argv, handle_sys_args
 
 clean_up_sys_argv()


### PR DESCRIPTION
Closes #18 

Note: Using pool/worker processes completely fixed the speed issue in the frame transformation part. Now the major bottleneck is combining the frames back into a video (~22sec on average with the test.mp4). Removing `-pix_fmt yuv420p` shaves off 5sec, but then some players might not be able to play the final video. Besides that, extracting the frames takes ~5sec.